### PR TITLE
Add 'soft' flag to retain operations that prevents the overwriting of existing formatting.

### DIFF
--- a/lib/delta.js
+++ b/lib/delta.js
@@ -34,12 +34,14 @@ Delta.prototype['delete'] = function (length) {
   return this.push({ 'delete': length });
 };
 
-Delta.prototype.retain = function (length, attributes) {
+Delta.prototype.retain = function (length, attributes, soft) {
   if (length <= 0) return this;
   var newOp = { retain: length };
   if (attributes != null && typeof attributes === 'object' && Object.keys(attributes).length > 0) {
     newOp.attributes = attributes;
   }
+  if (soft)
+    newOp.soft = true;
   return this.push(newOp);
 };
 
@@ -70,6 +72,7 @@ Delta.prototype.push = function (newOp) {
       } else if (typeof newOp.retain === 'number' && typeof lastOp.retain === 'number') {
         this.ops[index - 1] = { retain: lastOp.retain + newOp.retain };
         if (typeof newOp.attributes === 'object') this.ops[index - 1].attributes = newOp.attributes
+        if (newOp.soft) this.ops[index - 1].soft = newOp.soft;
         return this;
       }
     }
@@ -162,7 +165,7 @@ Delta.prototype.compose = function (other) {
           newOp.insert = thisOp.insert;
         }
         // Preserve null when composing with a retain, otherwise remove it for inserts
-        var attributes = op.attributes.compose(thisOp.attributes, otherOp.attributes, typeof thisOp.retain === 'number');
+        var attributes = op.attributes.compose(thisOp.attributes, otherOp.attributes, typeof thisOp.retain === 'number', otherOp.soft);
         if (attributes) newOp.attributes = attributes;
         delta.push(newOp);
       // Other op should be delete, we could be an insert or retain

--- a/lib/op.js
+++ b/lib/op.js
@@ -4,7 +4,7 @@ var extend = require('extend');
 
 var lib = {
   attributes: {
-    compose: function (a, b, keepNull) {
+    compose: function (a, b, keepNull, soft) {
       if (typeof a !== 'object') a = {};
       if (typeof b !== 'object') b = {};
       var attributes = extend(true, {}, b);
@@ -17,7 +17,7 @@ var lib = {
         }, {});
       }
       for (var key in a) {
-        if (a[key] !== undefined && b[key] === undefined) {
+        if (soft || (a[key] !== undefined && b[key] === undefined)) {
           attributes[key] = a[key];
         }
       }
@@ -96,6 +96,8 @@ Iterator.prototype.next = function (length) {
       }
       if (typeof nextOp.retain === 'number') {
         retOp.retain = length;
+        if (nextOp.soft !== undefined)
+          retOp.soft = nextOp.soft;
       } else if (typeof nextOp.insert === 'string') {
         retOp.insert = nextOp.insert.substr(offset, length);
       } else {


### PR DESCRIPTION
This ability is need in the fix for quilljs issue #1333

This is a preliminary pull request - would need documentation and unit test if this direction is supported.