### PR TITLE
[Doc] Update link/href format example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ In both cases of text and embeds, an optional `attributes` key can be defined wi
 { insert: "Text", attributes: { bold: true } }
 
 // Insert a link
-{ insert: "Google", attributes: { href: 'https://www.google.com' } }
+{ insert: "Google", attributes: { link: 'https://www.google.com' } }
 
 // Insert an embed
 {


### PR DESCRIPTION
Thank you for providing great light weight solution to the community. 

Link is format provided by quill/delta. Tested on Mac OS X with Chrome v51. Only attribute link works.