### PR TITLE
Include "files" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
     "tslint-plugin-prettier": "^1.3.0",
     "typescript": "^3.0.0"
   },
+  "files": [
+    "tsconfig.json",
+    "dist",
+    "src"
+  ],
   "license": "MIT",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Apparently it's bad to gitignore "dist" without having an npmignore or "files" clause that includes it again.  https://github.com/npm/npm/issues/18320