### PR TITLE
Use new fast-diff version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v4.1.0
+
+- Use fast-diff 1.2.0 in `diff()`, so that diffs do not split Unicode surrogate pairs
+
 ## v4.0.1
 
 - Fix build package casing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-delta",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -432,8 +432,8 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "github:jhchen/fast-diff#f4e19f4486123086679ee2c8f703efb44dfb2499",
-      "from": "github:jhchen/fast-diff#f4e19f4486123086679ee2c8f703efb44dfb2499"
+      "version": "1.2.0",
+      "resolved": "github:jhchen/fast-diff#f4e19f4486123086679ee2c8f703efb44dfb2499"
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-delta",
-  "version": "3.6.3",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,12 +14,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.0.tgz",
       "integrity": "sha512-Eo8NQCbgjlMPQarlFAE3vpyCvFda4dg1Ob5ZJb6BJI9x4NAZVWowyMNB8GJJDgDI4lr2oqiQvXlPB0Fn1NoXnQ==",
-      "dev": true
-    },
-    "@types/fast-diff": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/fast-diff/-/fast-diff-1.1.0.tgz",
-      "integrity": "sha512-doBwHnPAGdE54EiIFc0/v1qHlRVtNTaxgCZOS9SdSGPq91vx3kUKi5fmz/yivW/RAXEOUJYVXtVFQ6IPpqKRWg==",
       "dev": true
     },
     "abbrev": {
@@ -438,9 +432,8 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+      "version": "github:jhchen/fast-diff#f4e19f4486123086679ee2c8f703efb44dfb2499",
+      "from": "github:jhchen/fast-diff#f4e19f4486123086679ee2c8f703efb44dfb2499"
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-delta",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Format for representing rich text documents and changes.",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/quilljs/delta",
@@ -8,12 +8,11 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "extend": "^3.0.2",
-    "fast-diff": "1.1.2"
+    "fast-diff": "github:jhchen/fast-diff#f4e19f4486123086679ee2c8f703efb44dfb2499"
   },
   "devDependencies": {
     "@types/deep-equal": "^1.0.1",
     "@types/extend": "^3.0.0",
-    "@types/fast-diff": "^1.1.0",
     "coveralls": "^3.0.2",
     "istanbul": "~0.4.5",
     "jasmine": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-delta",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Format for representing rich text documents and changes.",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/quilljs/delta",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "extend": "^3.0.2",
-    "fast-diff": "github:jhchen/fast-diff#f4e19f4486123086679ee2c8f703efb44dfb2499"
+    "fast-diff": "1.2.0"
   },
   "devDependencies": {
     "@types/deep-equal": "^1.0.1",

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -264,7 +264,7 @@ class Delta {
     return delta;
   }
 
-  diff(other: Delta, index?: number): Delta {
+  diff(other: Delta, cursor?: number | diff.CursorInfo): Delta {
     if (this.ops === other.ops) {
       return new Delta();
     }
@@ -280,7 +280,7 @@ class Delta {
         .join('');
     });
     const retDelta = new Delta();
-    const diffResult = diff(strings[0], strings[1], index);
+    const diffResult = diff(strings[0], strings[1], cursor);
     const thisIter = Op.iterator(this.ops);
     const otherIter = Op.iterator(other.ops);
     diffResult.forEach(component => {


### PR DESCRIPTION
Bump minor version since this adds minor new functionality.