### PR TITLE
Turn off esModuleInterop and fix up imports

### DIFF
--- a/src/AttributeMap.ts
+++ b/src/AttributeMap.ts
@@ -1,5 +1,5 @@
-import equal from 'deep-equal';
-import extend from 'extend';
+import equal = require('deep-equal');
+import extend = require('extend');
 
 interface AttributeMap {
   [key: string]: any;

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -1,6 +1,6 @@
-import equal from 'deep-equal';
-import extend from 'extend';
-import diff from 'fast-diff';
+import equal = require('deep-equal');
+import extend = require('extend');
+import diff = require('fast-diff');
 import AttributeMap from './AttributeMap';
 import Op from './Op';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "ES5",
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "noErrorTruncation": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true


### PR DESCRIPTION
With imports that require esModuleInterop: true, all consumers of quill-delta must also have esModuleInterop: true. This is not always true, specifically for @types/quill. Since @types/quill depends on quill-delta, users will hit a Typescript compile error unless they, too, turn on esModuleInterop.

The best solution is to turn it off and return the import statements to the old style.