### PR TITLE
Fix bug in diff() method while formatLine() called

### DIFF
--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -271,7 +271,7 @@ class Delta {
     const strings = [this, other].map(delta => {
       return delta
         .map(op => {
-          if (op.insert != null) {
+          if (op.insert != null || op.retain != null) {
             return typeof op.insert === 'string' ? op.insert : NULL_CHARACTER;
           }
           const prep = delta === other ? 'on' : 'with';


### PR DESCRIPTION
I found that 'insert' property is required in diff(). But there is no 'insert' property in the delta object which returned by calling formatLine() method and only 'retain' property exists.