### PR TITLE
Fix retain inversion across multiple ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v4.2.1
+
+- Fix invert retain across multiple ops
+
 ## v4.2.0
 
 - Add `invert()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-delta",
-  "version": "4.1.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -39,6 +39,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -594,7 +595,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -743,6 +745,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -786,7 +789,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "mime-db": {
       "version": "1.35.0",
@@ -943,7 +947,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "request": {
       "version": "2.87.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-delta",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Format for representing rich text documents and changes.",
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "https://github.com/quilljs/delta",

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -375,7 +375,7 @@ class Delta {
             inverted.push(baseOp);
           } else if (op.retain && op.attributes) {
             inverted.retain(
-              op.retain,
+              Op.length(baseOp),
               AttributeMap.invert(op.attributes, baseOp.attributes),
             );
           }

--- a/test/delta/invert.js
+++ b/test/delta/invert.js
@@ -28,6 +28,15 @@ describe('invert()', function() {
     expect(base.compose(delta).compose(inverted)).toEqual(base);
   });
 
+  it('retain on a delta with different attributes', function() {
+    var base = new Delta().insert('123').insert('4', { bold: true });
+    var delta = new Delta().retain(4, { italic: true });
+    var expected = new Delta().retain(4, { italic: null });
+    var inverted = delta.invert(base);
+    expect(expected).toEqual(inverted);
+    expect(base.compose(delta).compose(inverted)).toEqual(base);
+  });
+
   it('combined', function() {
     var delta = new Delta()
       .retain(2)


### PR DESCRIPTION
Consider this base document:

```js
new Delta()
  .insert('123')
  .insert('4', { bold: true });
```

And this delta:

```js
new Delta().retain(4, { italic: true });
```

This simply applies italic to the whole document. We'd expect the
inverse to remove italic:

```js
new Delta().retain(4, { italic: null });
```

However, we currently get an inverse op with the wrong `retain` length:

```js
new Delta().retain(8, { italic: null });
```

This is because when we parse multiple ops in the inversion, we use the
original op's `retain` value (in this case `4` gets used twice), instead
of the length of the individual ops (`3` and then `1`).

This change updates the inversion to use the correct length for the
inverted `retain`.