### PR TITLE
Support complex / deep / nested attributes

### DIFF
--- a/test/attributes.js
+++ b/test/attributes.js
@@ -84,6 +84,93 @@ describe('AttributeMap', function() {
         ),
       ).toEqual(attributes);
     });
+
+    describe('complex attribute', function() {
+      it('add a new property', function() {
+        expect(
+          AttributeMap.compose(
+            {complex: {foo: 123}},
+            {complex: {bar: 456}},
+          ),
+        ).toEqual({
+          complex: {
+            foo: 123,
+            bar: 456,
+          },
+        });
+      });
+
+      it('overwrite an existing property', function() {
+        expect(
+          AttributeMap.compose(
+            {complex: {foo: 123}},
+            {complex: {foo: 456}},
+          ),
+        ).toEqual({
+          complex: {foo: 456},
+        });
+      });
+
+      it('remove an existing property', function() {
+        expect(
+          AttributeMap.compose(
+            {complex: {foo: 123, bar: 456}},
+            {complex: {foo: null}},
+          ),
+        ).toEqual({
+          complex: {bar: 456},
+        });
+      });
+
+      it('remove the last property', function() {
+        expect(
+          AttributeMap.compose(
+            {complex: {foo: 123}},
+            {complex: {foo: null}},
+          ),
+        ).toBeUndefined();
+      });
+
+      it('overwrites arrays', function() {
+        expect(
+          AttributeMap.compose(
+            {complex: {foo: [1, 2, 3]}},
+            {complex: {foo: [1, 3]}},
+          ),
+        ).toEqual({complex: {foo: [1, 3]}});
+      });
+
+      it('deep mix of operations', function() {
+        expect(
+          AttributeMap.compose(
+            {
+              complex: {
+                foo: {
+                  bar: 123,
+                  baz: 'abc',
+                },
+              },
+            },
+            {
+              complex: {
+                foo: {
+                  bar: 456
+                },
+                qux: 'def',
+              },
+            },
+          ),
+        ).toEqual({
+          complex: {
+            foo: {
+              bar: 456,
+              baz: 'abc',
+            },
+            qux: 'def',
+          },
+        });
+      });
+    });
   });
 
   describe('diff()', function() {
@@ -118,6 +205,72 @@ describe('AttributeMap', function() {
       var overwritten = { bold: true, color: 'blue' };
       var expected = { color: 'blue' };
       expect(AttributeMap.diff(format, overwritten)).toEqual(expected);
+    });
+
+    describe('complex attribute', function () {
+      it('same format', function() {
+        expect(
+          AttributeMap.diff(
+            {complex: {foo: 123}},
+            {complex: {foo: 123}},
+          ),
+        ).toBeUndefined();
+      });
+
+      it('change the only property', function() {
+        expect(
+          AttributeMap.diff(
+            {complex: {foo: 123}},
+            {complex: {foo: 456}},
+          ),
+        ).toEqual({
+          complex: {foo: 456},
+        });
+      });
+
+      it('change one property but not another', function() {
+        expect(
+          AttributeMap.diff(
+            {complex: {foo: 123, bar: 456}},
+            {complex: {foo: 789, bar: 456}},
+          ),
+        ).toEqual({
+          complex: {foo: 789},
+        });
+      });
+
+      it('add a property', function() {
+        expect(
+          AttributeMap.diff(
+            {complex: {foo: 123}},
+            {complex: {foo: 123, bar: 456}},
+          ),
+        ).toEqual({
+          complex: {bar: 456},
+        });
+      });
+
+      it('remove a property', function() {
+        expect(
+          AttributeMap.diff(
+            {complex: {foo: 123, bar: 456}},
+            {complex: {foo: 123}},
+          ),
+        ).toEqual({
+          complex: {bar: null},
+        });
+      });
+
+      it('array', function() {
+        expect(
+          AttributeMap.diff(
+            {complex: {foo: [1, 2, 3]}},
+            {complex: {foo: [1, 3]}},
+          ),
+        ).toEqual({
+          complex: {foo: [1, 3]},
+        });
+      });
     });
   });
 
@@ -171,6 +324,43 @@ describe('AttributeMap', function() {
       var expected = { bold: null, italic: true, color: 'blue' };
       expect(AttributeMap.invert(attributes, base)).toEqual(expected);
     });
+
+    describe('complex attribute', function() {
+      it('add property', function() {
+        var attributes = {complex: {bar: 456}};
+        var base = {complex: {foo: 123}};
+        var expected = {complex: {bar: null}};
+        expect(AttributeMap.invert(attributes, base)).toEqual(expected);
+      });
+
+      it('remove property', function() {
+        var attributes = {complex: {bar: null}};
+        var base = {complex: {foo: 123, bar: 456}};
+        var expected = {complex: {bar: 456}};
+        expect(AttributeMap.invert(attributes, base)).toEqual(expected);
+      });
+
+      it('update existing property', function() {
+        var attributes = {complex: {foo: 789}};
+        var base = {complex: {foo: 123, bar: 456}};
+        var expected = {complex: {foo: 123}};
+        expect(AttributeMap.invert(attributes, base)).toEqual(expected);
+      });
+
+      it('array', function() {
+        var attributes = {complex: {foo: [1, 3]}};
+        var base = {complex: {foo: [1, 2, 3]}};
+        var expected = {complex: {foo: [1, 2, 3]}};
+        expect(AttributeMap.invert(attributes, base)).toEqual(expected);
+      });
+
+      it('deep change', function() {
+        var attributes = {complex: {foo: {bar: null}}};
+        var base = {complex: {foo: {bar: 123, baz: 456}}};
+        var expected = {complex: {foo: {bar: 123}}};
+        expect(AttributeMap.invert(attributes, base)).toEqual(expected);
+      });
+    });
   });
 
   describe('transform()', function() {
@@ -199,6 +389,37 @@ describe('AttributeMap', function() {
 
     it('without priority', function() {
       expect(AttributeMap.transform(left, right, false)).toEqual(right);
+    });
+
+    describe('complex attribute', function() {
+      it('with priority', function() {
+        expect(
+          AttributeMap.transform(
+            {complex: {foo: 123, bar: 456}},
+            {complex: {foo: 789, baz: 'abc'}},
+            true,
+          ),
+        ).toEqual({complex: {baz: 'abc'}});
+      });
+
+      it('without priority', function () {
+        expect(
+          AttributeMap.transform(
+            {complex: {foo: 123, bar: 456}},
+            {complex: {foo: 789, baz: 'abc'}},
+            false,
+          ),
+        ).toEqual({complex: {foo: 789, baz: 'abc'}});
+      });
+
+      it('array', function() {
+        expect(
+          AttributeMap.transform(
+            {complex: {foo: [1, 2, 3]}},
+            {complex: {foo: [4, 5, 6]}},
+          ),
+        ).toEqual({complex: {foo: [4, 5, 6]}});
+      });
     });
   });
 });


### PR DESCRIPTION
This change adds support for complex attributes, which might have
arbitrarily nested properties:

```json
{
  "insert": "some text",
  "attributes": {
    "complexAttribute": {
      "prop1": {
        "subPropA": "a",
        "subPropB": 2
      },
      "prop2": true
    }
  }
}
```

## Motivation

The particular use case with which this was written in mind is the
addition of comments to Quill. That is, the ability to select part of a
document, and add some extra information about that selection.

Comments can be applied to arbitrary content, so cannot be represented
as an embed (for example). They naturally belong to the attributes:

```json
{
  "insert": "This text is commented",
  "attributes": {
    "comment": "comment-id"
  }
}
```

The issue with comments is that multiple comments may exist on the same
range:

```json
{
  "insert": "this text is commented",
  "attributes": {
    "comment": {
      "comment-id-1": true,
      "comment-id-2": true
    }
  }
}
```

These cannot be "flattened", because the IDs are arbitrary strings,
which:

  - could collide with other attributes who rely on IDs like this
  - does not map neatly to a Quill attributor / blot

Any other metadata-like attributes may also benefit from this sort of
deeply nested structure. For example, a naive git-blame-like feature
might look like:

```json
{
  "insert": "\n",
  "attributes": {
    "blame": {
      "hash1": {
        "author": "Alec Gibson",
        "timestamp": 1582123032,
      }
    }
  }
}
```

## Implementation

This change adds support to all of `compose`, `diff`, `invert` and
`transform` for complex attributes.

The implementation is recursive, and each depth of attributes is
treated similarly to the top level. In particular:

  - `null` will remove a property
  - an empty object is treated as `null`

```javascript
const attributes = {complex: {foo: 123}}
const update = {complex: {foo: null}}
AttributeMap.compose(attributes, update) // => undefined
```

### Arrays

Note that arrays are out-of-scope of this change. Their behaviour is not
well defined when composing deltas together, and they are treated as if
they are primitive values (ie they directly overwrite one another,
rather than attempt a deep change).

## Quill integration

Quill will not natively support these changes, and further work will be
required if this capability is to be adopted there. Given that Quill v2
is currently in development, this may be a good time to do this work, if
desirable.

In particular:

  - `format()` methods need to `compose` values rather than simply
    overwrite
  - `merge()` methods need to perform deep equality checks, rather than
    object reference checks

Note that Quill can currently support these complex attributes, but only
with blots that override the above methods.

## Backwards compatibility

This change is not technically backwards-compatible. If anyone is
already using deeply nested attributes and relying on the current
all-or-nothing behaviour, then this change will break their code.