### PR TITLE
fix rollup warning

### DIFF
--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -451,4 +451,5 @@ class Delta {
   }
 }
 
-export = Delta;
+export default Delta;
+export { AttributeMap };


### PR DESCRIPTION
Error: 'AttributeMap' is not exported by ..\node_modules\quill-delta\lib\delta.js, imported by ..\core\editor.js
import Delta, { AttributeMap } from 'quill-delta';