### PR TITLE
fix attributes transform cause inconsistent

### DIFF
--- a/src/AttributeMap.ts
+++ b/src/AttributeMap.ts
@@ -85,15 +85,17 @@ namespace AttributeMap {
     if (typeof b !== 'object') {
       return undefined;
     }
+    let baseAttrs = {};
     if (!priority) {
-      return b; // b simply overwrites us without priority
+      baseAttrs = cloneDeep(b);
+      [a as AttributeMap, b as AttributeMap] = [b, a];
     }
     const attributes = Object.keys(b).reduce<AttributeMap>((attrs, key) => {
       if (a[key] === undefined) {
         attrs[key] = b[key]; // null is a valid value
       }
       return attrs;
-    }, {});
+    }, baseAttrs);
     return Object.keys(attributes).length > 0 ? attributes : undefined;
   }
 }

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -198,7 +198,12 @@ describe('AttributeMap', function() {
     });
 
     it('without priority', function() {
-      expect(AttributeMap.transform(left, right, false)).toEqual(right);
+      expect(AttributeMap.transform(left, right, false)).toEqual({
+        color: 'blue',
+        font: 'serif',
+        italic: true,
+        bold: true,
+      });
     });
   });
 });

--- a/test/delta/transform.js
+++ b/test/delta/transform.js
@@ -73,7 +73,7 @@ describe('transform()', function() {
     var a2 = new Delta().retain(1, { color: 'blue' });
     var b2 = new Delta().retain(1, { bold: true, color: 'red' });
     var expected1 = new Delta().retain(1, { bold: true, color: 'red' });
-    var expected2 = new Delta().retain(1, { color: 'blue' });
+    var expected2 = new Delta().retain(1, { color: 'blue', bold: true });
     expect(a1.transform(b1, false)).toEqual(expected1);
     expect(b2.transform(a2, false)).toEqual(expected2);
   });


### PR DESCRIPTION
Consider use sharedb:

ClientA applies Oa as an Op and send it to the server: 
```
{ attributes: { header: 1 } }
```
ClientB applies Ob as an Op and send it to the server: 
```
{ attributes: { list: 'ordered' } }
```
The Server applies Oa first, transform: 
```
 Ob' = Oa.transform(Ob, true) = { attributes: { header: 1, list: 'ordered' } }
```
The Server applies Ob', then acknowledges Oa to ClientA, sends Ob' to ClientA
ClientA applies Ob'
Now the server is identical with ClientA:
```
{ attributes: { header: 1, list: 'ordered' } }
```

The Server sends Oa to ClientB
ClientB transform: 
```
Oa' = Ob.transform(Oa, false) = { attributes: { header: 1 } }
```
ClientB applies Oa'
ClientB is: 
```
{ attributes: { list: 'ordered', header: 1 } }
```

Now ClientB is different from ClientA:
* ClientB:  the text's format is header
* ClientA: the text's format is list
