### PR TITLE
fix attributes transform cause inconsistent

### DIFF
--- a/src/AttributeMap.ts
+++ b/src/AttributeMap.ts
@@ -85,15 +85,23 @@ namespace AttributeMap {
     if (typeof b !== 'object') {
       return undefined;
     }
+
+    let attributes = {};
+
     if (!priority) {
-      return b; // b simply overwrites us without priority
+      attributes = Object.keys(b).reduce<AttributeMap>((attrs, key) => {
+        attrs[key] = b[key];
+        return attrs;
+      }, cloneDeep(a));
+    } else {
+      attributes = Object.keys(b).reduce<AttributeMap>((attrs, key) => {
+        if (a[key] === undefined) {
+          attrs[key] = b[key]; // null is a valid value
+        }
+        return attrs;
+      }, {});
     }
-    const attributes = Object.keys(b).reduce<AttributeMap>((attrs, key) => {
-      if (a[key] === undefined) {
-        attrs[key] = b[key]; // null is a valid value
-      }
-      return attrs;
-    }, {});
+
     return Object.keys(attributes).length > 0 ? attributes : undefined;
   }
 }

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -198,7 +198,12 @@ describe('AttributeMap', function() {
     });
 
     it('without priority', function() {
-      expect(AttributeMap.transform(left, right, false)).toEqual(right);
+      expect(AttributeMap.transform(left, right, false)).toEqual({
+        bold: true,
+        color: 'blue',
+        font: 'serif',
+        italic: true
+      });
     });
   });
 });

--- a/test/delta/transform.js
+++ b/test/delta/transform.js
@@ -73,7 +73,7 @@ describe('transform()', function() {
     var a2 = new Delta().retain(1, { color: 'blue' });
     var b2 = new Delta().retain(1, { bold: true, color: 'red' });
     var expected1 = new Delta().retain(1, { bold: true, color: 'red' });
-    var expected2 = new Delta().retain(1, { color: 'blue' });
+    var expected2 = new Delta().retain(1, { bold: true, color: 'blue' });
     expect(a1.transform(b1, false)).toEqual(expected1);
     expect(b2.transform(a2, false)).toEqual(expected2);
   });


### PR DESCRIPTION
```javascript
const a = new Delta().retain(1, { header: 1 })
const b = new Delta().retain(1, { list: 'ordered' })

a.compose(a.transform(b, true))
// {"ops":[{"retain":1,"attributes":{"list":"ordered","header":1}}]}

b.compose(b.transform(a, false))
// {"ops":[{"retain":1,"attributes":{"header":1,"list":"ordered"}}]}
```
a's final format is **header**, b's final format is **list**. some attributes are incompatible with each other.
