### PR TITLE
Export Delta as default class

### DIFF
--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -451,4 +451,4 @@ class Delta {
   }
 }
 
-export = Delta;
+export default Delta;


### PR DESCRIPTION
For some reason, the other Source Files in this project have a proper default export, but Delta.ts does not, which requires the `allowSyntheticDefaultImports` flag to be true for the TypeScript compiler