### PR TITLE
Remove unused lint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,15 +48,7 @@
       "sourceType": "module"
     },
     "rules": {
-      "@typescript-eslint/ban-ts-ignore": "off",
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-namespace": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        {
-          "argsIgnorePattern": "^_"
-        }
-      ]
+      "@typescript-eslint/no-namespace": "off"
     }
   },
   "prettier": {

--- a/src/AttributeMap.ts
+++ b/src/AttributeMap.ts
@@ -2,7 +2,7 @@ import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
 
 interface AttributeMap {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 namespace AttributeMap {


### PR DESCRIPTION
These rules that make linter looser are not used so can just remove them.
We can add them back when they become necessary.

### Breaking changes

The only usage of `any` is `AttributeMap`. This PR changes it to `unknown`,
which can represent any types like `any` but requires type assertions or control
flow based narrowing. It can be considered as a type-safe version of `any` and as a library, it's better to use it instead of `any` to avoid users from writing type-unsafe code.

However, this introduces a breaking change for TypeScript users as they have to change their code to either narrowing the types explicitly or using `as any` as we currently do for them.

### Test plan
Make sure lint passes.