### PR TITLE
Support retaining embeds

### DIFF
--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -38,11 +38,11 @@ class Delta {
   static AttributeMap = AttributeMap;
   private static handlers: { [embedType: string]: EmbedHandler } = {};
 
-  static registerHandler(embedType: string, handler: EmbedHandler): void {
+  static registerEmbed(embedType: string, handler: EmbedHandler): void {
     this.handlers[embedType] = handler;
   }
 
-  static unregisterHandler(embedType: string): void {
+  static unregisterEmbed(embedType: string): void {
     delete this.handlers[embedType];
   }
 

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -498,9 +498,12 @@ class Delta {
         } else if (otherOp.delete) {
           delta.push(otherOp);
         } else {
-          let transformedData: Op['retain'] = length;
           const thisData = thisOp.retain;
           const otherData = otherOp.retain;
+          let transformedData: Op['retain'] =
+            typeof otherData === 'object' && otherData !== null
+              ? otherData
+              : length;
           if (
             typeof thisData === 'object' &&
             thisData !== null &&

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -453,7 +453,8 @@ class Delta {
         });
         return baseIndex + length;
       } else if (typeof op.retain === 'object' && op.retain !== null) {
-        const baseOp = new OpIterator(base.ops).next();
+        const slice = base.slice(baseIndex, baseIndex + 1);
+        const baseOp = new OpIterator(slice.ops).next();
         const [embedType, opData, baseOpData] = getEmbedTypeAndData(
           op.retain,
           baseOp.insert,
@@ -463,6 +464,7 @@ class Delta {
           { [embedType]: handler.invert(opData, baseOpData) },
           AttributeMap.invert(op.attributes, baseOp.attributes),
         );
+        return baseIndex + 1;
       }
       return baseIndex;
     }, 0);

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -317,7 +317,8 @@ class Delta {
           // Insert + delete cancels out
         } else if (
           typeof otherOp.delete === 'number' &&
-          typeof thisOp.retain === 'number'
+          (typeof thisOp.retain === 'number' ||
+            (typeof thisOp.retain === 'object' && thisOp.retain !== null))
         ) {
           delta.push(otherOp);
         }

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -8,7 +8,7 @@ import OpIterator from './OpIterator';
 const NULL_CHARACTER = String.fromCharCode(0); // Placeholder char for embed in diff()
 
 interface EmbedHandler {
-  compose<T>(a: T, b: T): T;
+  compose<T>(a: T, b: T, keepNull: boolean): T;
   invert<T>(a: T, b: T): T;
   transform<T>(a: T, b: T, priority: boolean): T;
 }
@@ -285,7 +285,11 @@ class Delta {
               );
               const handler = Delta.getHandler(embedType);
               newOp[action] = {
-                [embedType]: handler.compose(thisData, otherData),
+                [embedType]: handler.compose(
+                  thisData,
+                  otherData,
+                  action === 'retain',
+                ),
               };
             }
           }

--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -16,7 +16,7 @@ interface EmbedHandler {
 const getEmbedTypeAndData = (
   a: Op['insert'] | Op['retain'],
   b: Op['insert'],
-): [string, any, any] => {
+): [string, unknown, unknown] => {
   if (typeof a !== 'object' || a === null) {
     throw new Error(`cannot retain a ${typeof a}`);
   }
@@ -93,7 +93,7 @@ class Delta {
   }
 
   retain(
-    length: number | Record<string, any>,
+    length: number | Record<string, unknown>,
     attributes?: AttributeMap,
   ): this {
     if (typeof length === 'number' && length <= 0) {

--- a/src/Op.ts
+++ b/src/Op.ts
@@ -4,7 +4,7 @@ interface Op {
   // only one property out of {insert, delete, retain} will be present
   insert?: string | Record<string, unknown>;
   delete?: number;
-  retain?: number | object;
+  retain?: number | Record<string, unknown>;
 
   attributes?: AttributeMap;
 }

--- a/src/Op.ts
+++ b/src/Op.ts
@@ -4,7 +4,7 @@ interface Op {
   // only one property out of {insert, delete, retain} will be present
   insert?: string | Record<string, unknown>;
   delete?: number;
-  retain?: number;
+  retain?: number | object;
 
   attributes?: AttributeMap;
 }
@@ -15,6 +15,8 @@ namespace Op {
       return op.delete;
     } else if (typeof op.retain === 'number') {
       return op.retain;
+    } else if (typeof op.retain === 'object' && op.retain !== null) {
+      return 1;
     } else {
       return typeof op.insert === 'string' ? op.insert.length : 1;
     }

--- a/src/OpIterator.ts
+++ b/src/OpIterator.ts
@@ -39,6 +39,12 @@ export default class Iterator {
         }
         if (typeof nextOp.retain === 'number') {
           retOp.retain = length;
+        } else if (
+          typeof nextOp.retain === 'object' &&
+          nextOp.retain !== null
+        ) {
+          // offset should === 0, length should === 1
+          retOp.retain = nextOp.retain;
         } else if (typeof nextOp.insert === 'string') {
           retOp.insert = nextOp.insert.substr(offset, length);
         } else {
@@ -66,10 +72,14 @@ export default class Iterator {
   }
 
   peekType(): string {
-    if (this.ops[this.index]) {
-      if (typeof this.ops[this.index].delete === 'number') {
+    const op = this.ops[this.index];
+    if (op) {
+      if (typeof op.delete === 'number') {
         return 'delete';
-      } else if (typeof this.ops[this.index].retain === 'number') {
+      } else if (
+        typeof op.retain === 'number' ||
+        (typeof op.retain === 'object' && op.retain !== null)
+      ) {
         return 'retain';
       } else {
         return 'insert';

--- a/test/delta/compose.js
+++ b/test/delta/compose.js
@@ -249,5 +249,12 @@ describe('compose()', () => {
       });
       expect(a.compose(b)).toEqual(expected);
     });
+
+    it('keeps other delete when this op is a retain', () => {
+      var a = new Delta().retain({ delta: [{ insert: 'a' }] });
+      var b = new Delta().insert('\n').delete(1);
+      var expected = new Delta().insert('\n').delete(1);
+      expect(a.compose(b)).toEqual(expected);
+    });
   });
 });

--- a/test/delta/compose.js
+++ b/test/delta/compose.js
@@ -212,14 +212,14 @@ describe('compose()', () => {
 
   describe('custom embed handler', () => {
     beforeEach(() => {
-      Delta.registerHandler('delta', {
+      Delta.registerEmbed('delta', {
         compose: (a, b) => new Delta(a).compose(new Delta(b)).ops,
         invert: (a, b) => new Delta(a).invert(new Delta(b)).ops,
       });
     });
 
     afterEach(() => {
-      Delta.unregisterHandler('delta');
+      Delta.unregisterEmbed('delta');
     });
 
     it('retain an embed with a number', () => {

--- a/test/delta/invert.js
+++ b/test/delta/invert.js
@@ -97,36 +97,36 @@ describe('invert()', () => {
     });
 
     it('invert an embed change with numbers', () => {
-      var delta = new Delta()
+      const delta = new Delta()
         .retain(1)
         .retain(1, { bold: true })
         .retain({ delta: [{ insert: 'b' }] });
-      var base = new Delta()
+      const base = new Delta()
         .insert('\n\n')
         .insert({ delta: [{ insert: 'a' }] });
 
-      var expected = new Delta()
+      const expected = new Delta()
         .retain(1)
         .retain(1, { bold: null })
         .retain({
           delta: [{ delete: 1 }],
         });
-      var inverted = delta.invert(base);
+      const inverted = delta.invert(base);
       expect(expected).toEqual(inverted);
       expect(base.compose(delta).compose(inverted)).toEqual(base);
     });
 
     it('respects base attributes', () => {
-      var delta = new Delta()
+      const delta = new Delta()
         .delete(1)
         .retain(1, { header: 2 })
         .retain({ delta: [{ insert: 'b' }] }, { padding: 10, margin: 0 });
-      var base = new Delta()
+      const base = new Delta()
         .insert('\n')
         .insert('\n', { header: 1 })
         .insert({ delta: [{ insert: 'a' }] }, { margin: 10 });
 
-      var expected = new Delta()
+      const expected = new Delta()
         .insert('\n')
         .retain(1, { header: 1 })
         .retain(
@@ -135,30 +135,37 @@ describe('invert()', () => {
           },
           { padding: null, margin: 10 },
         );
-      var inverted = delta.invert(base);
+      const inverted = delta.invert(base);
       expect(expected).toEqual(inverted);
       expect(base.compose(delta).compose(inverted)).toEqual(base);
     });
 
     it('works with multiple embeds', () => {
-      var delta = new Delta()
+      const delta = new Delta()
         .retain(1)
         .retain({ delta: [{ delete: 1 }] })
         .retain({ delta: [{ delete: 1 }] });
 
-      var base = new Delta()
+      const base = new Delta()
         .insert('\n')
         .insert({ delta: [{ insert: 'a' }] })
         .insert({ delta: [{ insert: 'b' }] });
 
-      var expected = new Delta()
+      const expected = new Delta()
         .retain(1)
         .retain({ delta: [{ insert: 'a' }] })
         .retain({ delta: [{ insert: 'b' }] });
 
-      var inverted = delta.invert(base);
+      const inverted = delta.invert(base);
       expect(expected).toEqual(inverted);
       expect(base.compose(delta).compose(inverted)).toEqual(base);
+    });
+
+    it('invert a string', () => {
+      const delta = new Delta().retain({ delta: [{ insert: 'a' }] });
+      const base = new Delta().insert('a');
+
+      expect(() => delta.invert(base)).toThrowError('cannot retain a string');
     });
   });
 });

--- a/test/delta/invert.js
+++ b/test/delta/invert.js
@@ -95,5 +95,70 @@ describe('invert()', () => {
       expect(expected).toEqual(inverted);
       expect(base.compose(delta).compose(inverted)).toEqual(base);
     });
+
+    it('invert an embed change with numbers', () => {
+      var delta = new Delta()
+        .retain(1)
+        .retain(1, { bold: true })
+        .retain({ delta: [{ insert: 'b' }] });
+      var base = new Delta()
+        .insert('\n\n')
+        .insert({ delta: [{ insert: 'a' }] });
+
+      var expected = new Delta()
+        .retain(1)
+        .retain(1, { bold: null })
+        .retain({
+          delta: [{ delete: 1 }],
+        });
+      var inverted = delta.invert(base);
+      expect(expected).toEqual(inverted);
+      expect(base.compose(delta).compose(inverted)).toEqual(base);
+    });
+
+    it('respects base attributes', () => {
+      var delta = new Delta()
+        .delete(1)
+        .retain(1, { header: 2 })
+        .retain({ delta: [{ insert: 'b' }] }, { padding: 10, margin: 0 });
+      var base = new Delta()
+        .insert('\n')
+        .insert('\n', { header: 1 })
+        .insert({ delta: [{ insert: 'a' }] }, { margin: 10 });
+
+      var expected = new Delta()
+        .insert('\n')
+        .retain(1, { header: 1 })
+        .retain(
+          {
+            delta: [{ delete: 1 }],
+          },
+          { padding: null, margin: 10 },
+        );
+      var inverted = delta.invert(base);
+      expect(expected).toEqual(inverted);
+      expect(base.compose(delta).compose(inverted)).toEqual(base);
+    });
+
+    it('works with multiple embeds', () => {
+      var delta = new Delta()
+        .retain(1)
+        .retain({ delta: [{ delete: 1 }] })
+        .retain({ delta: [{ delete: 1 }] });
+
+      var base = new Delta()
+        .insert('\n')
+        .insert({ delta: [{ insert: 'a' }] })
+        .insert({ delta: [{ insert: 'b' }] });
+
+      var expected = new Delta()
+        .retain(1)
+        .retain({ delta: [{ insert: 'a' }] })
+        .retain({ delta: [{ insert: 'b' }] });
+
+      var inverted = delta.invert(base);
+      expect(expected).toEqual(inverted);
+      expect(base.compose(delta).compose(inverted)).toEqual(base);
+    });
   });
 });

--- a/test/delta/invert.js
+++ b/test/delta/invert.js
@@ -64,14 +64,14 @@ describe('invert()', () => {
 
   describe('custom embed handler', () => {
     beforeEach(() => {
-      Delta.registerHandler('delta', {
+      Delta.registerEmbed('delta', {
         compose: (a, b) => new Delta(a).compose(new Delta(b)).ops,
         invert: (a, b) => new Delta(a).invert(new Delta(b)).ops,
       });
     });
 
     afterEach(() => {
-      Delta.unregisterHandler('delta');
+      Delta.unregisterEmbed('delta');
     });
 
     it('invert a normal change', () => {

--- a/test/delta/transform.js
+++ b/test/delta/transform.js
@@ -152,7 +152,7 @@ describe('transform()', () => {
 
   describe('custom embed handler', () => {
     beforeEach(() => {
-      Delta.registerHandler('delta', {
+      Delta.registerEmbed('delta', {
         compose: () => null,
         invert: () => null,
         transform: (a, b, priority) =>
@@ -161,7 +161,7 @@ describe('transform()', () => {
     });
 
     afterEach(() => {
-      Delta.unregisterHandler('delta');
+      Delta.unregisterEmbed('delta');
     });
 
     it('transform an embed change', () => {

--- a/test/delta/transform.js
+++ b/test/delta/transform.js
@@ -165,9 +165,9 @@ describe('transform()', () => {
     });
 
     it('transform an embed change with number', () => {
-      var a = new Delta().retain(1);
-      var b = new Delta().retain({ delta: [{ insert: 'b' }] });
-      var expected = new Delta().retain({
+      const a = new Delta().retain(1);
+      const b = new Delta().retain({ delta: [{ insert: 'b' }] });
+      const expected = new Delta().retain({
         delta: [{ insert: 'b' }],
       });
       expect(a.transform(b, true)).toEqual(expected);

--- a/test/delta/transform.js
+++ b/test/delta/transform.js
@@ -164,6 +164,16 @@ describe('transform()', () => {
       Delta.unregisterEmbed('delta');
     });
 
+    it('transform an embed change with number', () => {
+      var a = new Delta().retain(1);
+      var b = new Delta().retain({ delta: [{ insert: 'b' }] });
+      var expected = new Delta().retain({
+        delta: [{ insert: 'b' }],
+      });
+      expect(a.transform(b, true)).toEqual(expected);
+      expect(a.transform(b)).toEqual(expected);
+    });
+
     it('transform an embed change', () => {
       const a = new Delta().retain({ delta: [{ insert: 'a' }] });
       const b = new Delta().retain({ delta: [{ insert: 'b' }] });

--- a/test/delta/transform.js
+++ b/test/delta/transform.js
@@ -149,4 +149,30 @@ describe('transform()', () => {
     expect(a1).toEqual(a2);
     expect(b1).toEqual(b2);
   });
+
+  describe('custom embed handler', () => {
+    beforeEach(() => {
+      Delta.registerHandler('delta', {
+        compose: () => null,
+        invert: () => null,
+        transform: (a, b, priority) =>
+          new Delta(a).transform(new Delta(b), priority).ops,
+      });
+    });
+
+    afterEach(() => {
+      Delta.unregisterHandler('delta');
+    });
+
+    it('transform an embed change', () => {
+      const a = new Delta().retain({ delta: [{ insert: 'a' }] });
+      const b = new Delta().retain({ delta: [{ insert: 'b' }] });
+      const expected1 = new Delta().retain({
+        delta: [{ retain: 1 }, { insert: 'b' }],
+      });
+      const expected2 = new Delta().retain({ delta: [{ insert: 'b' }] });
+      expect(a.transform(b, true)).toEqual(expected1);
+      expect(a.transform(b)).toEqual(expected2);
+    });
+  });
 });


### PR DESCRIPTION
This PR adds support for retaining embeds, making it possible for nested data structure transforming.

This PR doesn't introduce breaking changes but a quick note is the previous changes (https://github.com/quilljs/delta/pull/58, upgrading TypeScript, `insert: string | object` -> `insert: string | Record<string, unknown>`) break BC so the next version should be a major bump. 